### PR TITLE
chore: Update Rust to 1.87.0 and dependencies (v2)

### DIFF
--- a/src/internal/commands/ford.rs
+++ b/src/internal/commands/ford.rs
@@ -12,7 +12,7 @@ use crate::{
 use anyhow::Context;
 use clap::Args;
 use log::info;
-use std::{ops::Deref, path::PathBuf};
+use std::path::PathBuf;
 use thiserror::Error;
 
 use super::InternalCommandOptions;
@@ -105,7 +105,7 @@ pub fn for_every_dart_project(
         );
 
         if let Err(error) = &result {
-            let error = error.deref().clone();
+            let error = error.clone();
             if options.fail_fast {
                 return Err(error).context(format!(
                     "trying to run command '{}' on project '{}'",

--- a/src/internal/commands/fua.rs
+++ b/src/internal/commands/fua.rs
@@ -12,7 +12,7 @@ use crate::{
 use anyhow::Context;
 use clap::Args;
 use log::info;
-use std::{ops::Deref, path::PathBuf};
+use std::path::PathBuf;
 use thiserror::Error;
 
 use super::InternalCommandOptions;
@@ -139,7 +139,7 @@ pub fn fvm_use_for_every_flutter_project(
         );
 
         if let Err(error) = &result {
-            let error = error.deref().clone();
+            let error = error.clone();
             if options.fail_fast {
                 return Err(error).context(format!(
                     "trying to run command '{}' on project '{}'",


### PR DESCRIPTION
Updates Rust to 1.87.0 and upgrades all dependencies. This PR incorporates changes from commit 7ee2d1c (cherry-picked onto main) and replaces the closed PR #3. Some doctests are currently failing and will be addressed in a follow-up.